### PR TITLE
feature: Add titleCase helper with tests and re-export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { slugify } from "./slugify.js";
+export { titleCase } from "./titleCase.js";

--- a/src/titleCase.test.ts
+++ b/src/titleCase.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { titleCase } from "./titleCase.js";
+
+describe("titleCase", () => {
+  test("capitalizes two words", () => {
+    expect(titleCase("hello world")).toBe("Hello World");
+  });
+
+  test("capitalizes a single word", () => {
+    expect(titleCase("hello")).toBe("Hello");
+  });
+
+  test("empty string stays empty", () => {
+    expect(titleCase("")).toBe("");
+  });
+
+  test("collapses multiple spaces", () => {
+    expect(titleCase("hello   world")).toBe("Hello World");
+  });
+
+  test("normalizes mixed case input", () => {
+    expect(titleCase("hELLo WoRLD")).toBe("Hello World");
+  });
+
+  test("preserves punctuation attached to words", () => {
+    expect(titleCase("it's a test")).toBe("It's A Test");
+  });
+
+  test("uppercases the first alphabetic character in a word", () => {
+    expect(titleCase(`"hello" world`)).toBe(`"Hello" World`);
+  });
+});

--- a/src/titleCase.ts
+++ b/src/titleCase.ts
@@ -1,0 +1,20 @@
+export function titleCase(input: string): string {
+  return input
+    .split(/\s+/)
+    .filter((word) => word.length > 0)
+    .map((word) => {
+      const normalizedWord = word.toLowerCase();
+      const firstLetterIndex = normalizedWord.search(/\p{L}/u);
+
+      if (firstLetterIndex === -1) {
+        return normalizedWord;
+      }
+
+      return (
+        normalizedWord.slice(0, firstLetterIndex) +
+        normalizedWord.charAt(firstLetterIndex).toUpperCase() +
+        normalizedWord.slice(firstLetterIndex + 1)
+      );
+    })
+    .join(" ");
+}


### PR DESCRIPTION
## Add titleCase helper with tests and re-export

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #7

### Changes
Create src/titleCase.ts exporting titleCase(input: string): string that splits the input on whitespace and uppercases the first letter of each resulting word, lowercasing the rest of each word so mixed-case input is normalized. Preserve an empty string as empty, and collapse runs of whitespace by using a split on /\s+/ (filtering empties) while joining with a single space. Punctuation attached to a word should stay attached to the word, and only the first alphabetic character of each word is uppercased. Add src/titleCase.test.ts with at least 6 test cases covering: basic two-word input ('hello world' -> 'Hello World'), single word ('hello' -> 'Hello'), empty string ('' -> ''), multiple spaces between words (e.g. 'hello   world' -> 'Hello World'), mixed case input ('hELLo WoRLD' -> 'Hello World'), and punctuation (e.g. "it's a test" -> "It's A Test"). Re-export titleCase from src/index.ts by adding `export { titleCase } from "./titleCase.js";` alongside the existing slugify export. Follow the style and import conventions used in src/slugify.ts and src/slugify.test.ts (note the .js extension in relative imports).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*