### PR TITLE
feature: Add camelCase helper with tests

### DIFF
--- a/src/camelCase.test.ts
+++ b/src/camelCase.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { camelCase } from "./camelCase.js";
+
+describe("camelCase", () => {
+  test("converts a basic two-word phrase", () => {
+    expect(camelCase("hello world")).toBe("helloWorld");
+  });
+
+  test("keeps a single lowercase word unchanged", () => {
+    expect(camelCase("hello")).toBe("hello");
+  });
+
+  test("converts kebab-case input", () => {
+    expect(camelCase("hello-world")).toBe("helloWorld");
+  });
+
+  test("converts snake_case input", () => {
+    expect(camelCase("hello_world")).toBe("helloWorld");
+  });
+
+  test("normalizes mixed-case input", () => {
+    expect(camelCase("hELLo woRLD")).toBe("helloWorld");
+  });
+
+  test("keeps an empty string empty", () => {
+    expect(camelCase("")).toBe("");
+  });
+
+  test("collapses extra separator runs", () => {
+    expect(camelCase("  hello__world   again--here  ")).toBe(
+      "helloWorldAgainHere",
+    );
+  });
+});

--- a/src/camelCase.ts
+++ b/src/camelCase.ts
@@ -1,0 +1,18 @@
+export function camelCase(input: string): string {
+  const words = input.split(/[\s_-]+/).filter((word) => word.length > 0);
+  const [firstWord, ...restWords] = words;
+
+  if (firstWord === undefined) {
+    return "";
+  }
+
+  return (
+    firstWord.toLowerCase() +
+    restWords
+      .map(
+        (word) =>
+          word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+      )
+      .join("")
+  );
+}


### PR DESCRIPTION
## Add camelCase helper with tests

**Category:** `feature` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #9

### Changes
Create `src/camelCase.ts` exporting `camelCase(input: string): string`. It must convert whitespace/underscore/dash-separated words to camelCase (first word lowercased, subsequent words capitalised). Examples: `"hello world"` → `"helloWorld"`, `"Hello_World"` → `"helloWorld"`, `"hello-world"` → `"helloWorld"`. Pure, deterministic, zero dependencies. Create `src/camelCase.test.ts` following the `slugify.test.ts` style (import from `./camelCase.js`, use vitest `describe`/`test`/`expect`). Include at least 6 test cases covering: basic two-word phrase, single word passthrough, kebab input, snake input, mixed-case input, empty string, and extra whitespace/collapsing separator runs.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*