### PR TITLE
feature: Add kebabCase helper with tests

### DIFF
--- a/src/kebabCase.test.ts
+++ b/src/kebabCase.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { kebabCase } from "./kebabCase.js";
+
+describe("kebabCase", () => {
+  test("joins a basic two-word phrase with dashes", () => {
+    expect(kebabCase("Hello World")).toBe("hello-world");
+  });
+
+  test("converts camelCase input", () => {
+    expect(kebabCase("helloWorld")).toBe("hello-world");
+  });
+
+  test("converts snake_case input", () => {
+    expect(kebabCase("hello_world")).toBe("hello-world");
+  });
+
+  test("lowercases a single word", () => {
+    expect(kebabCase("Hello")).toBe("hello");
+  });
+
+  test("keeps an empty string empty", () => {
+    expect(kebabCase("")).toBe("");
+  });
+
+  test("collapses runs of separators and trims edges", () => {
+    expect(kebabCase("  hello   __world--test  ")).toBe("hello-world-test");
+  });
+});

--- a/src/kebabCase.ts
+++ b/src/kebabCase.ts
@@ -1,0 +1,8 @@
+export function kebabCase(input: string): string {
+  return input
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/([A-Z])([A-Z][a-z])/g, "$1-$2")
+    .replace(/[\s_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+}


### PR DESCRIPTION
## Add kebabCase helper with tests

**Category:** `feature` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #8

### Changes
Create `src/kebabCase.ts` exporting `kebabCase(input: string): string`. Converts whitespace/underscore-separated and camelCase words to kebab-case (all lowercase, dash-joined). Examples: `"Hello World"` → `"hello-world"`, `"helloWorld"` → `"hello-world"`, `"hello_world"` → `"hello-world"`. Pure, deterministic, zero dependencies. Create `src/kebabCase.test.ts` in the slugify.test.ts style (import from `./kebabCase.js`). Include at least 6 test cases covering: basic two-word phrase, camelCase input, snake input, single word, empty string, and extra whitespace/collapsing separator runs. Note: this is distinct from slugify — no diacritic stripping required, but it should still collapse runs of separators.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*